### PR TITLE
fix: corrigir repositório nos workflows do GitHub App

### DIFF
--- a/.github/workflows/auto-refactor-issues.yml
+++ b/.github/workflows/auto-refactor-issues.yml
@@ -34,7 +34,7 @@ jobs:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_PRIVATE_KEY }}
           owner: 'PageCloudv1'
-          repositories: 'xcloud-bot'
+          repositories: 'xcloud-mcp'
 
       - name: '� Aplicar Auto-Atribuição Simples'
         uses: 'actions/github-script@v7'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_PRIVATE_KEY }}
           owner: 'PageCloudv1'
-          repositories: 'xcloud-bot'
+          repositories: 'xcloud-mcp'
       
       # Step 2: Hardening de segurança do runner
       - name: '🛡️ Harden Runner'

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -72,7 +72,7 @@ jobs:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_PRIVATE_KEY }}
           owner: 'PageCloudv1'
-          repositories: 'xcloud-bot'
+          repositories: 'xcloud-mcp'
 
       - name: 'Extract command'
         id: 'extract_command'
@@ -141,7 +141,7 @@ jobs:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_PRIVATE_KEY }}
           owner: 'PageCloudv1'
-          repositories: 'xcloud-bot'
+          repositories: 'xcloud-mcp'
 
       - name: 'Send failure comment'
         env:

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -35,7 +35,7 @@ jobs:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_PRIVATE_KEY }}
           owner: 'PageCloudv1'
-          repositories: 'xcloud-bot'
+          repositories: 'xcloud-mcp'
 
       - name: 'Checkout Repository'
         uses: 'actions/checkout@v4'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -109,7 +109,7 @@ jobs:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_PRIVATE_KEY }}
           owner: 'PageCloudv1'
-          repositories: 'xcloud-bot'
+          repositories: 'xcloud-mcp'
 
       - name: 'Post analysis comment'
         uses: 'actions/github-script@v7'


### PR DESCRIPTION
- ❌ Problema: Workflows tentavam gerar token para 'xcloud-bot'
- ✅ Solução: Gerar token para 'xcloud-mcp' (repo correto)

Workflows corrigidos:
- auto-refactor-issues.yml
- codeql-analysis.yml
- gemini-dispatch.yml (2 ocorrências)
- gemini-pr-review.yml
- gemini-triage.yml

Erro HTTP 403 (Resource not accessible by integration) resolvido.

Related to: #10